### PR TITLE
Fix SQL syntax error in db.js

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -134,7 +134,7 @@ export async function initDb() {
       NEW.updated_at = NOW();
       RETURN NEW;
     END;
-    $ LANGUAGE plpgsql;
+    $$ LANGUAGE plpgsql;
 
     -- Create triggers if they don't already exist
     DO $$
@@ -193,6 +193,7 @@ export async function initDb() {
         EXECUTE FUNCTION trigger_set_timestamp();
       END IF;
     END;
+    $$
   `)
 
   // Seed initial admin if table empty


### PR DESCRIPTION
The database initialization was failing with a "syntax error at or near '$'" due to incorrect dollar quoting in the `CREATE FUNCTION` and `DO` statements.

This commit corrects the syntax by using `$$` for dollar quoting, which is the standard way to define function bodies and `DO` blocks in PostgreSQL.